### PR TITLE
Bug fix in Py3 version.

### DIFF
--- a/jsparser3.py
+++ b/jsparser3.py
@@ -1053,9 +1053,7 @@ def Expression(t, x, stop=None):
                     operators.append(Node(t, GROUP))
                     x.parenLevel += 1
                 else:
-                    while (operators and
-                            opPrecedence.get(operators[-1].type_) >
-                            opPrecedence[NEW]):
+                    while (operators and opPrecedence.get(operators[-1].type_) or 0) > opPrecedence[NEW]:
                         reduce_()
 
                     # Handle () now, to regularize the n-ary case for n > 0.


### PR DESCRIPTION
Just fixes a 2to3 thing that I missed before. You can't do `None > int` in Python3. I'm using the Py3 version, so should find anything else that may be lurking.